### PR TITLE
fixup zsh completion on ubuntu 16.10

### DIFF
--- a/local_setup
+++ b/local_setup
@@ -49,7 +49,7 @@ fi
 # load additional completion wrapper when SHELL == zsh
 if [[ "$(basename "${SHELL}")" == "zsh" ]]
 then
-    autoload bashcompinit
+    autoload -U bashcompinit
     bashcompinit
     autoload compinit
     compinit


### PR DESCRIPTION
omit error message: bashcompinit:134: parse error near `|'