### PR TITLE
Check if using zsh with the $ZSH_VERSION variable

### DIFF
--- a/local_setup
+++ b/local_setup
@@ -47,7 +47,7 @@ then
 fi
 
 # load additional completion wrapper when SHELL == zsh
-if [[ "$(basename "${SHELL}")" == "zsh" ]]
+if [ -n "$ZSH_VERSION" ]
 then
     autoload -U bashcompinit
     bashcompinit


### PR DESCRIPTION
For some reason the $SHELL variable is set to bash
even dough zsh is used. It seems that checking for
$ZSH_VERSION is safer.

See also:

https://stackoverflow.com/a/9911082