### PR TITLE
fix: preserve Linux capabilities during tar extraction

### DIFF
--- a/edi/lib/buildahhelpers.py
+++ b/edi/lib/buildahhelpers.py
@@ -109,8 +109,8 @@ def create_container(name, source_artifact):
         cmd = [buildah_exec(), "--name", temp_container_name, "from", "scratch"]
         run(cmd, log_threshold=logging.INFO)
 
-        nested_command = ("fakeroot tar --numeric-owner -C " + r'${container_root}' + " -axf " +
-                          str(source_artifact.location))
+        nested_command = ("fakeroot tar --numeric-owner --xattrs --xattrs-include='*' -C " + r'${container_root}' +
+                          " -axf " + str(source_artifact.location))
 
         run_buildah_unshare(temp_container_name, nested_command)
     else:

--- a/edi/lib/edicommand.py
+++ b/edi/lib/edicommand.py
@@ -198,6 +198,8 @@ class EdiCommand(metaclass=CommandFactory):
         cmd = []
         cmd.append("tar")
         cmd.append("--numeric-owner")
+        cmd.append("--xattrs")
+        cmd.append("--xattrs-include='*'")
         cmd.extend(["-C", target_folder])
         cmd.extend(["-axf", image])
         run(cmd, sudo=True, log_threshold=logging.INFO)


### PR DESCRIPTION
Add --xattrs and --xattrs-include='*' flags to tar commands when extracting mmdebstrap-generated archives. This ensures extended attributes including security.capability are preserved, fixing issue #95 where capabilities set via Ansible were lost.

Closes #95